### PR TITLE
add time and bbox attrs to links

### DIFF
--- a/feeds/defaults.go
+++ b/feeds/defaults.go
@@ -19,6 +19,8 @@ const (
 	invaliddatetime = "invalid 'updated', needs to be a valid datetime with timezone see TG Requirement 11"
 	invalidauthor   = "invalid 'author', cannot be empty see TG Requirement 12"
 	invalidupdated  = "invalid 'updated', updated is required see TG Requirements 11"
+	invalidlinktime = "invalid 'link.time', needs to be a valid datetime with timezone see TG Recommendation 11"
+	invalidlinkbbox = "invalid 'link.bbox', needs to be a valid georss:bbox see TG Recommendation 10"
 )
 
 const (


### PR DESCRIPTION
# Omschrijving

Ondersteuning voor `time` en `bbox` attributen in `links`. Volgens TG recommendations 10 en 11 in:
https://inspire.ec.europa.eu/documents/Network_Services/Technical_Guidance_Download_Services_v3.1.pdf

https://dev.kadaster.nl/jira/browse/PDOK-14660

## Type verandering

- Nieuwe feature

# Checklist:

- [x] Ik heb de code in deze PR zelf nogmaals nagekeken
- [ ] Ik heb mijn code beter achtergelaten dan dat ik het aantrof
- [ ] De code is leesbaar en de moeilijke onderdelen zijn voorzien van commentaar
- [x] Ik heb de tests toegevoegd/uitgebreid indien nodig
- [x] Ik heb de tests gedraaid die de werking van mijn wijziging bewijst
- [ ] De [PDOK documentatie](https://github.com/PDOK/interne-documentatie) is bijgewerkt indien nodig.
- [ ] Er zit geen gevoelig informatie in deze PR (wachtwoorden etc)